### PR TITLE
coverage is too strict for the GWDM 1.1

### DIFF
--- a/docs/GWDM/1.1.md
+++ b/docs/GWDM/1.1.md
@@ -325,9 +325,9 @@ Age range in whole years of participants in the dataset. Please provide range in
 
 Male, Female, Other
         
-| title   | is_list   | is_optional   | required   | type                                                                                                                                           |
-|:--------|:----------|:--------------|:-----------|:-----------------------------------------------------------------------------------------------------------------------------------------------|
-| Gender  | False     | True          | False      | ["Gender[{'anyOf': [{'pattern': '\\\\b(?:Male|Female|Other)(?:,(?:Male|Female|Other))*\\\\b', 'type': 'string'}, {'type': 'null'}]}]", 'null'] |
+| title   | is_list   | is_optional   | required   | type                                                                                                      |
+|:--------|:----------|:--------------|:-----------|:----------------------------------------------------------------------------------------------------------|
+| Gender  | False     | True          | False      | ["CommaSeparatedValues[{'anyOf': [{'pattern': '([^,]+)', 'type': 'string'}, {'type': 'null'}]}]", 'null'] |
 
 
 
@@ -336,9 +336,9 @@ Male, Female, Other
 
 Blood, Saliva, Urine, Other
         
-| title              | is_list   | is_optional   | required   | type                                                                                                                                                                    |
-|:-------------------|:----------|:--------------|:-----------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Biological Samples | False     | True          | False      | ["BiologicalSamples[{'anyOf': [{'pattern': '\\\\b(?:Blood|Other|Urine|Saliva)(?:,(?:Blood|Other|Urine|Saliva))*\\\\b', 'type': 'string'}, {'type': 'null'}]}]", 'null'] |
+| title              | is_list   | is_optional   | required   | type                                                                                                      |
+|:-------------------|:----------|:--------------|:-----------|:----------------------------------------------------------------------------------------------------------|
+| Biological Samples | False     | True          | False      | ["CommaSeparatedValues[{'anyOf': [{'pattern': '([^,]+)', 'type': 'string'}, {'type': 'null'}]}]", 'null'] |
 
 
 
@@ -347,9 +347,9 @@ Blood, Saliva, Urine, Other
 
 Mental health, Cognitive function
         
-| title         | is_list   | is_optional   | required   | type                                                                                                                                                                                |
-|:--------------|:----------|:--------------|:-----------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Psychological | False     | True          | False      | ["Psychological[{'anyOf': [{'pattern': '\\\\b(?:Cognitive Function|Mental Health)(?:,(?:Cognitive Function|Mental Health))*\\\\b', 'type': 'string'}, {'type': 'null'}]}]", 'null'] |
+| title         | is_list   | is_optional   | required   | type                                                                                                      |
+|:--------------|:----------|:--------------|:-----------|:----------------------------------------------------------------------------------------------------------|
+| Psychological | False     | True          | False      | ["CommaSeparatedValues[{'anyOf': [{'pattern': '([^,]+)', 'type': 'string'}, {'type': 'null'}]}]", 'null'] |
 
 
 
@@ -358,9 +358,9 @@ Mental health, Cognitive function
 
 Cardiovascular, Respiratory, Musculoskeletal, Hearing and Vision, Reproductive
         
-| title    | is_list   | is_optional   | required   | type                                                                                                                                                                                                                                                       |
-|:---------|:----------|:--------------|:-----------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Physical | False     | True          | False      | ["Physical[{'anyOf': [{'pattern': '\\\\b(?:Respiratory|Vision|Hearing|Musculoskeletal|Cardiovascular|Reproductive)(?:,(?:Respiratory|Vision|Hearing|Musculoskeletal|Cardiovascular|Reproductive))*\\\\b', 'type': 'string'}, {'type': 'null'}]}]", 'null'] |
+| title    | is_list   | is_optional   | required   | type                                                                                                      |
+|:---------|:----------|:--------------|:-----------|:----------------------------------------------------------------------------------------------------------|
+| Physical | False     | True          | False      | ["CommaSeparatedValues[{'anyOf': [{'pattern': '([^,]+)', 'type': 'string'}, {'type': 'null'}]}]", 'null'] |
 
 
 
@@ -369,9 +369,9 @@ Cardiovascular, Respiratory, Musculoskeletal, Hearing and Vision, Reproductive
 
 Height, Weight, Waist circumference, Hip circumference, Blood pressure
         
-| title          | is_list   | is_optional   | required   | type                                                                                                                                                                                                                                                     |
-|:---------------|:----------|:--------------|:-----------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Anthropometric | False     | True          | False      | ["Anthropometric[{'anyOf': [{'pattern': '\\\\b(?:Blood Pressure|Hip Circumference|Height|Waist Circumference|Weight)(?:,(?:Blood Pressure|Hip Circumference|Height|Waist Circumference|Weight))*\\\\b', 'type': 'string'}, {'type': 'null'}]}]", 'null'] |
+| title          | is_list   | is_optional   | required   | type                                                                                                      |
+|:---------------|:----------|:--------------|:-----------|:----------------------------------------------------------------------------------------------------------|
+| Anthropometric | False     | True          | False      | ["CommaSeparatedValues[{'anyOf': [{'pattern': '([^,]+)', 'type': 'string'}, {'type': 'null'}]}]", 'null'] |
 
 
 
@@ -380,9 +380,9 @@ Height, Weight, Waist circumference, Hip circumference, Blood pressure
 
 Cohort lifestyle habits: Smoking, Physical activity, Dietary habits, Alcohol
         
-| title     | is_list   | is_optional   | required   | type                                                                                                                                                                                                             |
-|:----------|:----------|:--------------|:-----------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Lifestyle | False     | True          | False      | ["Lifestyles[{'anyOf': [{'pattern': '\\\\b(?:Smoking|Dietary Habits|Physical Activity|Alcohol)(?:,(?:Smoking|Dietary Habits|Physical Activity|Alcohol))*\\\\b', 'type': 'string'}, {'type': 'null'}]}]", 'null'] |
+| title     | is_list   | is_optional   | required   | type                                                                                                      |
+|:----------|:----------|:--------------|:-----------|:----------------------------------------------------------------------------------------------------------|
+| Lifestyle | False     | True          | False      | ["CommaSeparatedValues[{'anyOf': [{'pattern': '([^,]+)', 'type': 'string'}, {'type': 'null'}]}]", 'null'] |
 
 
 
@@ -391,9 +391,9 @@ Cohort lifestyle habits: Smoking, Physical activity, Dietary habits, Alcohol
 
 Occupation, Family circumstances, Housing, Education, Ethnic group, Marital status, Social support
         
-| title          | is_list   | is_optional   | required   | type                                                                                                                                                                                                                                                                                                                          |
-|:---------------|:----------|:--------------|:-----------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Socio-economic | False     | True          | False      | ["SocioEconomic[{'anyOf': [{'pattern': '\\\\b(?:Finances|Family Circumstances|Housing|Education|Marital Status|Occupation|Ethnic Group|Social Support)(?:,(?:Finances|Family Circumstances|Housing|Education|Marital Status|Occupation|Ethnic Group|Social Support))*\\\\b', 'type': 'string'}, {'type': 'null'}]}]", 'null'] |
+| title          | is_list   | is_optional   | required   | type                                                                                                      |
+|:---------------|:----------|:--------------|:-----------|:----------------------------------------------------------------------------------------------------------|
+| Socio-economic | False     | True          | False      | ["CommaSeparatedValues[{'anyOf': [{'pattern': '([^,]+)', 'type': 'string'}, {'type': 'null'}]}]", 'null'] |
 
 
 

--- a/docs/GWDM/1.1.structure.json
+++ b/docs/GWDM/1.1.structure.json
@@ -408,7 +408,7 @@
                         "description": "Male, Female, Other",
                         "examples": null,
                         "type": [
-                              "Gender[{'anyOf': [{'pattern': '\\\\b(?:Male|Female|Other)(?:,(?:Male|Female|Other))*\\\\b', 'type': 'string'}, {'type': 'null'}]}]",
+                              "CommaSeparatedValues[{'anyOf': [{'pattern': '([^,]+)', 'type': 'string'}, {'type': 'null'}]}]",
                               "null"
                         ],
                         "is_list": false,
@@ -422,7 +422,7 @@
                         "description": "Blood, Saliva, Urine, Other",
                         "examples": null,
                         "type": [
-                              "BiologicalSamples[{'anyOf': [{'pattern': '\\\\b(?:Blood|Other|Urine|Saliva)(?:,(?:Blood|Other|Urine|Saliva))*\\\\b', 'type': 'string'}, {'type': 'null'}]}]",
+                              "CommaSeparatedValues[{'anyOf': [{'pattern': '([^,]+)', 'type': 'string'}, {'type': 'null'}]}]",
                               "null"
                         ],
                         "is_list": false,
@@ -436,7 +436,7 @@
                         "description": "Mental health, Cognitive function",
                         "examples": null,
                         "type": [
-                              "Psychological[{'anyOf': [{'pattern': '\\\\b(?:Cognitive Function|Mental Health)(?:,(?:Cognitive Function|Mental Health))*\\\\b', 'type': 'string'}, {'type': 'null'}]}]",
+                              "CommaSeparatedValues[{'anyOf': [{'pattern': '([^,]+)', 'type': 'string'}, {'type': 'null'}]}]",
                               "null"
                         ],
                         "is_list": false,
@@ -450,7 +450,7 @@
                         "description": "Cardiovascular, Respiratory, Musculoskeletal, Hearing and Vision, Reproductive",
                         "examples": null,
                         "type": [
-                              "Physical[{'anyOf': [{'pattern': '\\\\b(?:Respiratory|Vision|Hearing|Musculoskeletal|Cardiovascular|Reproductive)(?:,(?:Respiratory|Vision|Hearing|Musculoskeletal|Cardiovascular|Reproductive))*\\\\b', 'type': 'string'}, {'type': 'null'}]}]",
+                              "CommaSeparatedValues[{'anyOf': [{'pattern': '([^,]+)', 'type': 'string'}, {'type': 'null'}]}]",
                               "null"
                         ],
                         "is_list": false,
@@ -464,7 +464,7 @@
                         "description": "Height, Weight, Waist circumference, Hip circumference, Blood pressure",
                         "examples": null,
                         "type": [
-                              "Anthropometric[{'anyOf': [{'pattern': '\\\\b(?:Blood Pressure|Hip Circumference|Height|Waist Circumference|Weight)(?:,(?:Blood Pressure|Hip Circumference|Height|Waist Circumference|Weight))*\\\\b', 'type': 'string'}, {'type': 'null'}]}]",
+                              "CommaSeparatedValues[{'anyOf': [{'pattern': '([^,]+)', 'type': 'string'}, {'type': 'null'}]}]",
                               "null"
                         ],
                         "is_list": false,
@@ -478,7 +478,7 @@
                         "description": "Cohort lifestyle habits: Smoking, Physical activity, Dietary habits, Alcohol",
                         "examples": null,
                         "type": [
-                              "Lifestyles[{'anyOf': [{'pattern': '\\\\b(?:Smoking|Dietary Habits|Physical Activity|Alcohol)(?:,(?:Smoking|Dietary Habits|Physical Activity|Alcohol))*\\\\b', 'type': 'string'}, {'type': 'null'}]}]",
+                              "CommaSeparatedValues[{'anyOf': [{'pattern': '([^,]+)', 'type': 'string'}, {'type': 'null'}]}]",
                               "null"
                         ],
                         "is_list": false,
@@ -492,7 +492,7 @@
                         "description": "Occupation, Family circumstances, Housing, Education, Ethnic group, Marital status, Social support",
                         "examples": null,
                         "type": [
-                              "SocioEconomic[{'anyOf': [{'pattern': '\\\\b(?:Finances|Family Circumstances|Housing|Education|Marital Status|Occupation|Ethnic Group|Social Support)(?:,(?:Finances|Family Circumstances|Housing|Education|Marital Status|Occupation|Ethnic Group|Social Support))*\\\\b', 'type': 'string'}, {'type': 'null'}]}]",
+                              "CommaSeparatedValues[{'anyOf': [{'pattern': '([^,]+)', 'type': 'string'}, {'type': 'null'}]}]",
                               "null"
                         ],
                         "is_list": false,

--- a/hdr_schemata/models/GWDM/1.1/schema.json
+++ b/hdr_schemata/models/GWDM/1.1/schema.json
@@ -176,30 +176,6 @@
                   ],
                   "title": "AgeRange"
             },
-            "Anthropometric": {
-                  "anyOf": [
-                        {
-                              "pattern": "\\b(?:Blood Pressure|Hip Circumference|Height|Waist Circumference|Weight)(?:,(?:Blood Pressure|Hip Circumference|Height|Waist Circumference|Weight))*\\b",
-                              "type": "string"
-                        },
-                        {
-                              "type": "null"
-                        }
-                  ],
-                  "title": "Anthropometric"
-            },
-            "BiologicalSamples": {
-                  "anyOf": [
-                        {
-                              "pattern": "\\b(?:Blood|Other|Urine|Saliva)(?:,(?:Blood|Other|Urine|Saliva))*\\b",
-                              "type": "string"
-                        },
-                        {
-                              "type": "null"
-                        }
-                  ],
-                  "title": "BiologicalSamples"
-            },
             "CommaSeparatedValues": {
                   "anyOf": [
                         {
@@ -274,7 +250,7 @@
                         "gender": {
                               "anyOf": [
                                     {
-                                          "$ref": "#/$defs/Gender"
+                                          "$ref": "#/$defs/CommaSeparatedValues"
                                     },
                                     {
                                           "type": "null"
@@ -287,7 +263,7 @@
                         "biologicalsamples": {
                               "anyOf": [
                                     {
-                                          "$ref": "#/$defs/BiologicalSamples"
+                                          "$ref": "#/$defs/CommaSeparatedValues"
                                     },
                                     {
                                           "type": "null"
@@ -300,7 +276,7 @@
                         "psychological": {
                               "anyOf": [
                                     {
-                                          "$ref": "#/$defs/Psychological"
+                                          "$ref": "#/$defs/CommaSeparatedValues"
                                     },
                                     {
                                           "type": "null"
@@ -313,7 +289,7 @@
                         "physical": {
                               "anyOf": [
                                     {
-                                          "$ref": "#/$defs/Physical"
+                                          "$ref": "#/$defs/CommaSeparatedValues"
                                     },
                                     {
                                           "type": "null"
@@ -326,7 +302,7 @@
                         "anthropometric": {
                               "anyOf": [
                                     {
-                                          "$ref": "#/$defs/Anthropometric"
+                                          "$ref": "#/$defs/CommaSeparatedValues"
                                     },
                                     {
                                           "type": "null"
@@ -339,7 +315,7 @@
                         "lifestyle": {
                               "anyOf": [
                                     {
-                                          "$ref": "#/$defs/Lifestyles"
+                                          "$ref": "#/$defs/CommaSeparatedValues"
                                     },
                                     {
                                           "type": "null"
@@ -352,7 +328,7 @@
                         "socioeconomic": {
                               "anyOf": [
                                     {
-                                          "$ref": "#/$defs/SocioEconomic"
+                                          "$ref": "#/$defs/CommaSeparatedValues"
                                     },
                                     {
                                           "type": "null"
@@ -701,30 +677,6 @@
                   "title": "FormatAndStandards",
                   "type": "object"
             },
-            "Gender": {
-                  "anyOf": [
-                        {
-                              "pattern": "\\b(?:Male|Female|Other)(?:,(?:Male|Female|Other))*\\b",
-                              "type": "string"
-                        },
-                        {
-                              "type": "null"
-                        }
-                  ],
-                  "title": "Gender"
-            },
-            "Lifestyles": {
-                  "anyOf": [
-                        {
-                              "pattern": "\\b(?:Smoking|Dietary Habits|Physical Activity|Alcohol)(?:,(?:Smoking|Dietary Habits|Physical Activity|Alcohol))*\\b",
-                              "type": "string"
-                        },
-                        {
-                              "type": "null"
-                        }
-                  ],
-                  "title": "Lifestyles"
-            },
             "Linkage": {
                   "additionalProperties": false,
                   "properties": {
@@ -1045,18 +997,6 @@
                   ],
                   "title": "Periodicity"
             },
-            "Physical": {
-                  "anyOf": [
-                        {
-                              "pattern": "\\b(?:Respiratory|Vision|Hearing|Musculoskeletal|Cardiovascular|Reproductive)(?:,(?:Respiratory|Vision|Hearing|Musculoskeletal|Cardiovascular|Reproductive))*\\b",
-                              "type": "string"
-                        },
-                        {
-                              "type": "null"
-                        }
-                  ],
-                  "title": "Physical"
-            },
             "Provenance": {
                   "additionalProperties": false,
                   "properties": {
@@ -1080,18 +1020,6 @@
                   ],
                   "title": "Provenance",
                   "type": "object"
-            },
-            "Psychological": {
-                  "anyOf": [
-                        {
-                              "pattern": "\\b(?:Cognitive Function|Mental Health)(?:,(?:Cognitive Function|Mental Health))*\\b",
-                              "type": "string"
-                        },
-                        {
-                              "type": "null"
-                        }
-                  ],
-                  "title": "Psychological"
             },
             "Required": {
                   "properties": {
@@ -1254,18 +1182,6 @@
                         }
                   ],
                   "title": "ShortTitle"
-            },
-            "SocioEconomic": {
-                  "anyOf": [
-                        {
-                              "pattern": "\\b(?:Finances|Family Circumstances|Housing|Education|Marital Status|Occupation|Ethnic Group|Social Support)(?:,(?:Finances|Family Circumstances|Housing|Education|Marital Status|Occupation|Ethnic Group|Social Support))*\\b",
-                              "type": "string"
-                        },
-                        {
-                              "type": "null"
-                        }
-                  ],
-                  "title": "SocioEconomic"
             },
             "StatisticalPopulationConstrained": {
                   "enum": [

--- a/hdr_schemata/models/GWDM/v1_1/Coverage.py
+++ b/hdr_schemata/models/GWDM/v1_1/Coverage.py
@@ -2,128 +2,45 @@ from hdr_schemata.models import remove_fields_from_cls
 from hdr_schemata.models.GWDM.v1_0 import Coverage as BaseCoverage
 import re
 from typing import Optional, List
-from pydantic import Field, RootModel, constr
-
-
-def get_pattern(allowed_phrases):
-    return (
-        r"\b(?:"
-        + "|".join(allowed_phrases)
-        + r")(?:,(?:"
-        + "|".join(allowed_phrases)
-        + r"))*\b"
-    )
-
-
-class Anthropometric(RootModel):
-    root: Optional[
-        constr(
-            pattern=get_pattern(
-                [
-                    "Blood Pressure",
-                    "Hip Circumference",
-                    "Height",
-                    "Waist Circumference",
-                    "Weight",
-                ]
-            )
-        )
-    ]
-
-
-class BiologicalSamples(RootModel):
-    root: Optional[constr(pattern=get_pattern(["Blood", "Other", "Urine", "Saliva"]))]
-
-
-class Physical(RootModel):
-    root: Optional[
-        constr(
-            pattern=get_pattern(
-                [
-                    "Respiratory",
-                    "Vision",
-                    "Hearing",
-                    "Musculoskeletal",
-                    "Cardiovascular",
-                    "Reproductive",
-                ]
-            )
-        )
-    ]
-
-
-class Psychological(RootModel):
-    root: Optional[constr(pattern=get_pattern(["Cognitive Function", "Mental Health"]))]
-
-
-class Lifestyles(RootModel):
-    root: Optional[
-        constr(
-            pattern=get_pattern(
-                ["Smoking", "Dietary Habits", "Physical Activity", "Alcohol"]
-            )
-        )
-    ]
-
-
-class Gender(RootModel):
-    root: Optional[constr(pattern=get_pattern(["Male", "Female", "Other"]))]
-
-
-class SocioEconomic(RootModel):
-    root: Optional[
-        constr(
-            pattern=get_pattern(
-                [
-                    "Finances",
-                    "Family Circumstances",
-                    "Housing",
-                    "Education",
-                    "Marital Status",
-                    "Occupation",
-                    "Ethnic Group",
-                    "Social Support",
-                ]
-            )
-        )
-    ]
+from pydantic import Field
+from hdr_schemata.definitions.HDRUK import CommaSeparatedValues
 
 
 class Coverage(BaseCoverage):
     class Config:
         extra = "forbid"
 
-    gender: Optional[Gender] = Field(
+    gender: Optional[CommaSeparatedValues] = Field(
         None, title="Gender", description="Male, Female, Other"
     )
 
-    biologicalsamples: Optional[BiologicalSamples] = Field(
+    biologicalsamples: Optional[CommaSeparatedValues] = Field(
         None, title="Biological Samples", description="Blood, Saliva, Urine, Other"
     )
 
-    psychological: Optional[Psychological] = Field(
+    psychological: Optional[CommaSeparatedValues] = Field(
         None, title="Psychological", description="Mental health, Cognitive function"
     )
 
-    physical: Optional[Physical] = Field(
+    physical: Optional[CommaSeparatedValues] = Field(
         None,
         title="Physical",
         description="Cardiovascular, Respiratory, Musculoskeletal, Hearing and Vision, Reproductive",
     )
 
-    anthropometric: Optional[Anthropometric] = Field(
+    anthropometric: Optional[CommaSeparatedValues] = Field(
         None,
         title="Anthropometric",
         description="Height, Weight, Waist circumference, Hip circumference, Blood pressure",
     )
 
-    lifestyle: Optional[Lifestyles] = Field(
+    lifestyle: Optional[CommaSeparatedValues] = Field(
         None,
         title="Lifestyle",
         description="Cohort lifestyle habits: Smoking, Physical activity, Dietary habits, Alcohol",
     )
 
-    socioeconomic: Optional[SocioEconomic] = Field(
+    socioeconomic: Optional[CommaSeparatedValues] = Field(
         None,
         title="Socio-economic",
         description="Occupation, Family circumstances, Housing, Education, Ethnic group, Marital status, Social support",


### PR DESCRIPTION
New cohort variables are too restrictive for the GWDM, we might want to allow in extra allowed options...

Therefore it's best to have these are comma-separated-values and just control what words are allowed in via the HDRUK schema instead! 