### PR TITLE
fix -dataset linkage null

### DIFF
--- a/hdr_schemata/models/GWDM/2.0/schema.json
+++ b/hdr_schemata/models/GWDM/2.0/schema.json
@@ -622,7 +622,8 @@
                         }
                   },
                   "title": "DatasetLinkage",
-                  "type": "object"
+                  "type": "object",
+                  "default": null
             },
             "DeliveryLeadTimeV2": {
                   "enum": [


### PR DESCRIPTION
so php when using: `$response->json()` will translate empty objects into arrays: [see docs](https://www.php.net/manual/en/json.constants.php#constant.json-force-object),

We want schema to return us null not an empty object

